### PR TITLE
Divers fixes sur X2DELEC selector switch

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1531,9 +1531,9 @@ def DecodeInfoType10(DecData, infoType):
 			if IsCreated == False and Parameters["Mode4"] == "True":
 				nbrdevices=FreeUnit()
 				Domoticz.Device(Name=protocol + " - " + id,  Unit=nbrdevices, TypeName="Selector Switch", Switchtype=18, Image=12, Options=Options).Create()
-				Devices[nbrdevices].Update(nValue =0,sValue = str(status), Options = Options)
+				Devices[nbrdevices].Update(nValue =0, sValue = str(status), Options = Options)
 			elif IsCreated == True :
-				svalue = str(state)
+				svalue = str(status)
 				if Devices[nbrdevices].sValue != svalue:
 					Devices[nbrdevices].Update(nValue =0,sValue = svalue)
 	##############################################################################################################

--- a/plugin.py
+++ b/plugin.py
@@ -1535,7 +1535,7 @@ def DecodeInfoType10(DecData, infoType):
 				status = 70
 			if state == "8": #CENTRALISED
 				status = 80
-			Options = {"infoType":infoType, "id": str(id), "function": str(function), "protocol": str(protocol), "subType": str(SubType), "frequency": str(frequency), "LevelActions": "|||||||||", "LevelNames": "Off|HG|Eco|Moderat|Medio|Comfort|Assoc", "LevelOffHidden": "False", "SelectorStyle": "0"}
+			Options = {"infoType":infoType, "id": str(id), "area": str(area), "function": str(function), "protocol": str(protocol), "subType": str(SubType), "frequency": str(frequency), "LevelActions": "|||||||||", "LevelNames": "Off|HG|Eco|Moderat|Medio|Comfort|Assoc", "LevelOffHidden": "False", "SelectorStyle": "0"}
 			Domoticz.Debug("Options to find or set : " + str(Options))
 			filters = ('id', 'protocol', 'infoType', 'function')
 			for x in Devices:
@@ -1558,7 +1558,7 @@ def DecodeInfoType10(DecData, infoType):
 					Devices[nbrdevices].Update(nValue = nvalue,sValue = svalue)
 	##############################################################################################################
 		else :
-			Options = {"infoType":infoType, "id": str(id), "function": str(function), "protocol": str(protocol), "subType": str(SubType), "frequency": str(frequency)}
+			Options = {"infoType":infoType, "id": str(id), "area": str(area), "function": str(function), "protocol": str(protocol), "subType": str(SubType), "frequency": str(frequency)}
 			Domoticz.Debug("Options to find or set : " + str(Options))
 			filters = ('id', 'protocol', 'infoType', 'function')
 			for x in Devices:

--- a/plugin.py
+++ b/plugin.py
@@ -1518,10 +1518,11 @@ def DecodeInfoType10(DecData, infoType):
 				status = 80
 			Options = {"infoType":infoType, "id": str(id), "function": str(function), "protocol": str(protocol), "subType": str(SubType), "frequency": str(frequency), "LevelActions": "|||||||||", "LevelNames": "Off|HG|Eco|Moderat|Medio|Comfort|Assoc", "LevelOffHidden": "False", "SelectorStyle": "0"}
 			Domoticz.Debug("Options to find or set : " + str(Options))
+			filters = ('id', 'protocol', 'infoType', 'function')
 			for x in Devices:
 				DOptions = Devices[x].Options
-				Domoticz.Debug("scanning devices: "+repr(x) + repr(DOptions))
-				if {k: DOptions.get(k, None) for k in ('id', 'protocol', 'infoType')} == {k: Options.get(k, None) for k in ('id', 'protocol', 'infoType')}:
+				Domoticz.Debug("scanning devices: " + repr(x) + repr(DOptions))
+				if {k: DOptions.get(k, None) for k in filters} == {k: Options.get(k, None) for k in filters}:
 					IsCreated = True
 					nbrdevices=x
 					Domoticz.Log("Devices already exist. Unit=" + str(x))
@@ -1532,16 +1533,18 @@ def DecodeInfoType10(DecData, infoType):
 				Domoticz.Device(Name=protocol + " - " + id,  Unit=nbrdevices, TypeName="Selector Switch", Switchtype=18, Image=12, Options=Options).Create()
 				Devices[nbrdevices].Update(nValue =0,sValue = str(status), Options = Options)
 			elif IsCreated == True :
-				Devices[nbrdevices].Update(nValue =0,sValue = str(status))
+				svalue = str(state)
+				if Devices[nbrdevices].sValue != svalue:
+					Devices[nbrdevices].Update(nValue =0,sValue = svalue)
 	##############################################################################################################
 		else :
 			Options = {"infoType":infoType, "id": str(id), "function": str(function), "protocol": str(protocol), "subType": str(SubType), "frequency": str(frequency)}
 			Domoticz.Debug("Options to find or set : " + str(Options))
+			filters = ('id', 'protocol', 'infoType', 'function')
 			for x in Devices:
-				Domoticz.Debug("scanning devices: "+repr(x))
 				DOptions = Devices[x].Options
-	#				if Devices[x].Options == Options :
-				if {k: DOptions.get(k, None) for k in ('id', 'protocol', 'infoType')} == {k: Options.get(k, None) for k in ('id', 'protocol', 'infoType')}:
+				Domoticz.Debug("scanning devices: " + repr(x) + repr(DOptions))
+				if {k: DOptions.get(k, None) for k in filters} == {k: Options.get(k, None) for k in filters}:
 					IsCreated = True
 					nbrdevices=x
 					Domoticz.Log("Devices already exist. Unit=" + str(x))
@@ -1552,7 +1555,9 @@ def DecodeInfoType10(DecData, infoType):
 				Domoticz.Device(Name=protocol + " - " + id, Unit=nbrdevices, Type=16, Switchtype=0).Create()
 				Devices[nbrdevices].Update(nValue =0,sValue = str(state), Options = Options)
 			elif IsCreated == True :
-				Devices[nbrdevices].Update(nValue =0,sValue = str(state))
+				svalue = str(state)
+				if Devices[nbrdevices].sValue != svalue:
+					Devices[nbrdevices].Update(nValue =0,sValue = svalue)
 	except Exception as e:
 		Domoticz.Log("Error while decoding Infotype10 frame: " + repr(e))
 		return


### PR DESCRIPTION
1) prise en compte  function 1 ou 2 pour la selection ON/OFF ou Selecteur
2) conversion id en zone à la X10. L'utilisation de l'ID en X2DELEC génère une erreur
3) correction diverses typo
4) contrôle de l'aspect de l'icone

Cette version permet d'afficher l'état des devices X2D commandés par un autre dispositif autre que le RFPLAYER (testé avec un deltia 6.33) et permet de contrôler des devices X2D (testé avec 3 deltia 1.03) avec des sélecteurs créés manuellement.
Note: Attention on perd une partie des options si on modifie le selecteur après création (icone par exemple).

Idéalement dans SendtoRfplayer il faudrait tester la valeur de 'function' pour faire la mise à jour du switch selecteur ou du switch On/Off mais on ne devrait pas en avoir besoin car c'est fait automatiquement par le RFPLAYER en mode X2DELEC.

